### PR TITLE
feat(leaves): endpoint report y mejorar get leaves

### DIFF
--- a/src/modules/leave/controllers/leave_controller.py
+++ b/src/modules/leave/controllers/leave_controller.py
@@ -1,14 +1,15 @@
-from fastapi import APIRouter, status
-from typing import Optional
+from fastapi import APIRouter, status, Query
+from typing import Annotated
 from src.database.core import DatabaseSession
 from src.modules.auth.token import TokenDependency
 from src.modules.leave.schemas.leave_schemas import (
-    LeaveDocumentStatus,
+    GetRequest,
     LeavePublic,
-    LeaveRequestStatus,
     LeaveCreate,
     LeaveUpdate,
     LeaveTypePublic,
+    ReportRequest,
+    ReportResponse,
 )
 from src.modules.leave.services import leave_service
 
@@ -18,14 +19,22 @@ leave_router = APIRouter(prefix="/leaves", tags=["Leaves"])
 @leave_router.get("/", response_model=list[LeavePublic], status_code=status.HTTP_200_OK)
 async def get_leaves(
     session: DatabaseSession,
-    document_status: Optional[LeaveDocumentStatus] = None,
-    request_status: Optional[LeaveRequestStatus] = None,
-    employee_id: Optional[int] = None,
-    sector_id: Optional[int] = None,
+    request: Annotated[GetRequest, Query()],
 ):
     return leave_service.get_leaves(
-        session, document_status, request_status, employee_id, sector_id
+        session, request
     )
+
+
+@leave_router.get(
+    "/report", response_model=ReportResponse, status_code=status.HTTP_200_OK
+)
+async def get_report(
+    session: DatabaseSession,
+    token: TokenDependency,
+    request: Annotated[ReportRequest, Query()],
+):
+    return leave_service.report(session, token, request)
 
 
 @leave_router.get(

--- a/src/modules/leave/schemas/leave_schemas.py
+++ b/src/modules/leave/schemas/leave_schemas.py
@@ -71,3 +71,45 @@ class LeavePublic(BaseModel):
                 "La fecha de inicio no puede ser posterior a la fecha de fin."
             )
         return self
+
+
+class GetRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    document_statuses: Optional[list[LeaveDocumentStatus]] = None
+    request_statuses: Optional[list[LeaveRequestStatus]] = None
+    employee_ids: Optional[list[int]] = None
+    sector_ids: Optional[list[int]] = None
+    leave_type_ids: Optional[list[int]] = None
+    from_creation_date: Optional[date] = None
+    until_creation_date: Optional[date] = None
+
+    @model_validator(mode="after")
+    def validate_dates(self) -> "GetRequest":
+        if self.from_creation_date and self.until_creation_date:
+            if self.until_creation_date < self.from_creation_date:
+                raise ValueError("La fecha 'hasta' no puede ser anterior que la fecha 'desde'.")
+        return self
+
+
+class ReportRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    from_creation_date: Optional[date] = None
+    until_creation_date: Optional[date] = None
+    sector_ids: Optional[list[int]] = None
+    request_statuses: Optional[list[LeaveRequestStatus]] = None
+    leave_type_ids: Optional[list[int]] = None
+
+    @model_validator(mode="after")
+    def validate_dates(self) -> "ReportRequest":
+        if self.from_creation_date and self.until_creation_date:
+            if self.until_creation_date < self.from_creation_date:
+                raise ValueError("La fecha 'hasta' no puede ser anterior que la fecha 'desde'.")
+        return self
+
+
+class ReportResponse(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    report: dict[int, tuple[str, int]]


### PR DESCRIPTION
- Agregar endpoint GET /leaves/report para generar reporte de cantidad de solicitudes por tipo teniendo en cuenta los filtros por fechas, tipos, estados y sectores. Adicionalmente se devuelve el nombre de cada tipo para comodidad del desarrollador frontend.
- Mejorar endpoint GET /leaves para aceptar varios valores por cada filtro, y se le agrega los filtros faltantes para que tenga por lo menos los mismos que el endpoint de reportes.